### PR TITLE
Docker container and bash scripting combination

### DIFF
--- a/linux/nikita/docker.sh
+++ b/linux/nikita/docker.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+global_start=`date +%s`
+
+cleanup() {
+    if [ -f index.html ]; then
+        rm -f index.html
+    fi
+    if [ -d tmpf ]; then
+        rm -rf tmpf
+    fi
+    docker stop donotest >/dev/null 2>/dev/null
+    docker rm donotest >/dev/null 2>/dev/null
+    global_end=`date +%s`
+    echo "Total script execution time: $(( $global_end-$global_start )) seconds."
+}
+trap cleanup EXIT
+
+mkdir tmpf
+start=`date +%s`
+docker run -d --name donotest -p 80:80 0lmi/donotest >/dev/null 2>/dev/null
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+    echo "ERROR: unable to start docker container"
+    exit $exit_code
+fi
+
+while true; do
+  let n=$n+1
+  curl http://127.0.0.1 >/dev/null 2>/dev/null
+  if [ $? -eq 0 ]; then
+      end=`date +%s`
+      docker cp donotest:usr/local/apache2/htdocs/index.html $SCRIPT_DIR >/dev/null 2>/dev/null
+
+      OUTPUT=$( mktemp -p $SCRIPT_DIR/tmpf )
+      curl -s -H "Content-Type: text/html; charset=utf-8" --data-binary @index.html \
+          https://validator.w3.org/nu/?out=gnu >> $OUTPUT
+
+      val_errors=$( grep -i Error $OUTPUT | wc -l)
+      val_warnings=$( grep -i warning $OUTPUT | wc -l )
+
+      if [ $val_errors -ge 1 ]; then
+          echo "Validation not passed, errors: $val_errors warnings: $val_warnings"
+      else
+          echo "Validation passed, warnings: $val_warnings"
+      fi
+
+      docker stop donotest >/dev/null 2>/dev/null
+      break
+  elif [ $(($(date +%s)-$start)) -ge 15 ]; then
+      echo "15sec Error"
+      exit
+  fi
+done
+
+echo "Container fist answer detected in: $(($end-$start)) seconds."


### PR DESCRIPTION
Task:
Написать bash script реализующий следующую логику:
1) запустить docker контейнер используя образ 0lmi/donotest так, чтобы веб сервер был доступен на порту 8081 хостовой машины
2) вывести в консоль приблизительное время старта httpd с точностью +/- 1 сек (опционально можно вывести точное время)
3) вывести сообщение об ощибке и завершить работу скрипта, если веб сервер не стартонет на протяжении 15-ти секунд
4) скачать http://localhost:8081/index.html не позже чем через 1-2 секунды после старта httpd
5) проверить на валидность html в файле index.html используя https://validator.w3.org/
6) вывести в консоль human readable результат проверки (прошел/не прошел и если нет, то кол-во warnings/errors/etc…)
7) остановить запущенный контейнер при любом из сценариев завершения работы скрипта
8) вывести в консоль продолжительность работы скрипта в секундах
----
Output:
```
(index.html errors/warnings)
Script was runned ... seconds
Container fist answer detected in: ... seconds
```
